### PR TITLE
Pure python unit testing and explicit precision

### DIFF
--- a/reaclib.py
+++ b/reaclib.py
@@ -415,7 +415,7 @@ class Rate(object):
 
         # prefactor
         if not self.prefactor == 1.0:
-            prefactor_string = "{:0.15f}*".format(self.prefactor)
+            prefactor_string = "{:1.14e}*".format(self.prefactor)
         else:
             prefactor_string = ""
 
@@ -466,7 +466,7 @@ class Rate(object):
 
         # prefactor
         if not self.prefactor == 1.0:
-            prefactor_string = "{:0.15f}*".format(self.prefactor)
+            prefactor_string = "{:1.14e}*".format(self.prefactor)
         else:
             prefactor_string = ""
 
@@ -504,7 +504,7 @@ class Rate(object):
 
         # prefactor
         if not self.prefactor == 1.0:
-            prefactor_string = "{:0.15f} * ".format(self.prefactor)
+            prefactor_string = "{:1.14e} * ".format(self.prefactor).replace('e','d')
         else:
             prefactor_string = ""
 
@@ -555,7 +555,7 @@ class Rate(object):
 
         # prefactor
         if not self.prefactor == 1.0:
-            prefactor_string = "{:0.15f} * ".format(self.prefactor)
+            prefactor_string = "{:1.14e} * ".format(self.prefactor).replace('e','d')
         else:
             prefactor_string = ""
 

--- a/test/replace-standard.py
+++ b/test/replace-standard.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# Given a date-time string XYZ corresponding to a directory in pyreaclib/test/runs,
+# Replace the pyreaclib/test/standard files with the corresponding files in
+# pyreaclib/test/runs/XYZ
+
+from __future__ import print_function
+import os
+import shutil
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('datetime', type=str, nargs=1,
+                    help='Date-time string corresponding to a directory in pyreaclib/test/runs. The files in pyreaclib/test/standard will be replaced by their corresponding files in pyreaclib/test/runs/datetime.')
+args = parser.parse_args()
+
+# Setup some directory names
+dir_test = os.path.dirname(os.path.realpath(__file__))
+dir_runs = os.path.join(dir_test, 'runs')
+dir_standard = os.path.join(dir_test, 'standard')
+
+# Make a list of test cases from the directories in pyreaclib/test/standard
+test_cases = []
+for entry in os.listdir(dir_standard):
+    if os.path.isdir(os.path.join(dir_standard, entry)):
+        test_cases.append(entry)
+
+dir_run_replace = os.path.join(dir_runs, args.datetime[0])
+if not os.path.isdir(dir_run_replace):
+    print('ERROR: Supply a date-time string corresponding to a directory name within pyreaclib/test/runs')
+    exit()
+else:
+    print('Using test suite directory {}'.format(dir_run_replace))
+
+for tc in test_cases:
+    print('\n----------------------------------------')
+    print('Test case {}:'.format(tc))
+    print('----------------------------------------\n')
+
+    dir_tc = os.path.join(dir_run_replace, tc)
+    dir_std_tc = os.path.join(dir_standard, tc)
+    for file in os.listdir(dir_std_tc):
+        print('* Replacing file ')
+        print('* * {} '.format(os.path.join(dir_std_tc, file)))
+        print('with')
+        print('* * {}'.format(os.path.join(dir_tc, file)))
+        print('')
+        shutil.copy(os.path.join(dir_tc, file), dir_std_tc)
+
+    
+

--- a/test/standard/C_f90/network.f90
+++ b/test/standard/C_f90/network.f90
@@ -39,34 +39,34 @@ contains
     write(*,*) "T: ", T
     YDOT(net_meta%in) = ( &
        - Y(net_meta%in) * rxn_rates(net_meta%k_n_p) &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
        )
 
     YDOT(net_meta%ip) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
        + Y(net_meta%in) * rxn_rates(net_meta%k_n_p) &
        )
 
     YDOT(net_meta%ihe4) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
        )
 
     YDOT(net_meta%ic12) = ( &
-       - 2 * 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
-       - 2 * 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
-       - 2 * 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
+       - 2 * 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
+       - 2 * 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
+       - 2 * 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
        )
 
     YDOT(net_meta%ine20) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
        )
 
     YDOT(net_meta%ina23) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
        )
 
     YDOT(net_meta%img23) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
        )
 
 
@@ -137,7 +137,7 @@ contains
          )
 
       DJAC(net_meta%in,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
          )
 
       DJAC(net_meta%in,net_meta%ine20) = ( &
@@ -165,7 +165,7 @@ contains
          )
 
       DJAC(net_meta%ip,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
          )
 
       DJAC(net_meta%ip,net_meta%ine20) = ( &
@@ -193,7 +193,7 @@ contains
          )
 
       DJAC(net_meta%ihe4,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
          )
 
       DJAC(net_meta%ihe4,net_meta%ine20) = ( &
@@ -221,9 +221,9 @@ contains
          )
 
       DJAC(net_meta%ic12,net_meta%ic12) = ( &
-         - 2 * 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
-         - 2 * 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
-         - 2 * 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
+         - 2 * 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
+         - 2 * 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
+         - 2 * 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
          )
 
       DJAC(net_meta%ic12,net_meta%ine20) = ( &
@@ -251,7 +251,7 @@ contains
          )
 
       DJAC(net_meta%ine20,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
          )
 
       DJAC(net_meta%ine20,net_meta%ine20) = ( &
@@ -279,7 +279,7 @@ contains
          )
 
       DJAC(net_meta%ina23,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
          )
 
       DJAC(net_meta%ina23,net_meta%ine20) = ( &
@@ -307,7 +307,7 @@ contains
          )
 
       DJAC(net_meta%img23,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
          )
 
       DJAC(net_meta%img23,net_meta%ine20) = ( &

--- a/test/standard/URCA_f90/network.f90
+++ b/test/standard/URCA_f90/network.f90
@@ -39,26 +39,26 @@ contains
     write(*,*) "T: ", T
     YDOT(net_meta%in) = ( &
        - Y(net_meta%in) * rxn_rates(net_meta%k_n_p) &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
        )
 
     YDOT(net_meta%ip) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
        + Y(net_meta%in) * rxn_rates(net_meta%k_n_p) &
        )
 
     YDOT(net_meta%ihe4) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
        )
 
     YDOT(net_meta%ic12) = ( &
-       - 2 * 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
-       - 2 * 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
-       - 2 * 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
+       - 2 * 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
+       - 2 * 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
+       - 2 * 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
        )
 
     YDOT(net_meta%ine20) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12a_ne20) &
        )
 
     YDOT(net_meta%ine23) = ( &
@@ -68,12 +68,12 @@ contains
 
     YDOT(net_meta%ina23) = ( &
        - Y(net_meta%ina23) * rxn_rates(net_meta%k_na23_ne23) &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12p_na23) &
        + Y(net_meta%ine23) * rxn_rates(net_meta%k_ne23_na23) &
        )
 
     YDOT(net_meta%img23) = ( &
-       + 0.500000000000000 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
+       + 5.00000000000000d-01 * dens * Y(net_meta%ic12)**2 * rxn_rates(net_meta%k_c12_c12n_mg23) &
        )
 
 
@@ -144,7 +144,7 @@ contains
          )
 
       DJAC(net_meta%in,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
          )
 
       DJAC(net_meta%in,net_meta%ine20) = ( &
@@ -176,7 +176,7 @@ contains
          )
 
       DJAC(net_meta%ip,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
          )
 
       DJAC(net_meta%ip,net_meta%ine20) = ( &
@@ -208,7 +208,7 @@ contains
          )
 
       DJAC(net_meta%ihe4,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
          )
 
       DJAC(net_meta%ihe4,net_meta%ine20) = ( &
@@ -240,9 +240,9 @@ contains
          )
 
       DJAC(net_meta%ic12,net_meta%ic12) = ( &
-         - 2 * 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
-         - 2 * 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
-         - 2 * 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
+         - 2 * 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
+         - 2 * 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
+         - 2 * 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
          )
 
       DJAC(net_meta%ic12,net_meta%ine20) = ( &
@@ -274,7 +274,7 @@ contains
          )
 
       DJAC(net_meta%ine20,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12a_ne20) &
          )
 
       DJAC(net_meta%ine20,net_meta%ine20) = ( &
@@ -338,7 +338,7 @@ contains
          )
 
       DJAC(net_meta%ina23,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12p_na23) &
          )
 
       DJAC(net_meta%ina23,net_meta%ine20) = ( &
@@ -370,7 +370,7 @@ contains
          )
 
       DJAC(net_meta%img23,net_meta%ic12) = ( &
-         + 0.500000000000000 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
+         + 5.00000000000000d-01 * dens * 2*Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_c12n_mg23) &
          )
 
       DJAC(net_meta%img23,net_meta%ine20) = ( &

--- a/test/standard/chapters/chapters_rhs.py
+++ b/test/standard/chapters/chapters_rhs.py
@@ -173,7 +173,7 @@ def rhs(t, Y, rho, T):
     dYdt = np.zeros((nnuc), dtype=np.float64)
 
     dYdt[in] = (
-       -0.500000000000000*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
+       -5.00000000000000e-01*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
        -Y[in]*lambda_n_p
        -rho*Y[in]*Y[ip]*lambda_p_ng_d
        +3*Y[ib17]*lambda_b17_nnn_c14
@@ -184,11 +184,11 @@ def rhs(t, Y, rho, T):
        )
 
     dYdt[ip] = (
-       -0.500000000000000*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
-       -2*0.500000000000000*rho**2*Y[ip]**2*Y[ihe4]*lambda_he4_pphe3_he3
+       -5.00000000000000e-01*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
+       -2*5.00000000000000e-01*rho**2*Y[ip]**2*Y[ihe4]*lambda_he4_pphe3_he3
        -rho*Y[in]*Y[ip]*lambda_p_ng_d
        -rho*Y[ip]*Y[it]*lambda_t_pn_he3
-       +2*0.500000000000000*rho*Y[ihe3]**2*lambda_he3_he3pp_he4
+       +2*5.00000000000000e-01*rho*Y[ihe3]**2*lambda_he3_he3pp_he4
        +Y[in]*lambda_n_p
        )
 
@@ -204,17 +204,17 @@ def rhs(t, Y, rho, T):
        )
 
     dYdt[ihe3] = (
-       -2*0.500000000000000*rho*Y[ihe3]**2*lambda_he3_he3pp_he4
-       +0.500000000000000*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
-       +2*0.500000000000000*rho**2*Y[ip]**2*Y[ihe4]*lambda_he4_pphe3_he3
+       -2*5.00000000000000e-01*rho*Y[ihe3]**2*lambda_he3_he3pp_he4
+       +5.00000000000000e-01*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
+       +2*5.00000000000000e-01*rho**2*Y[ip]**2*Y[ihe4]*lambda_he4_pphe3_he3
        +rho*Y[ip]*Y[it]*lambda_t_pn_he3
        )
 
     dYdt[ihe4] = (
-       -3*0.166666666666667*rho**2*Y[ihe4]**3*lambda_he4_aag_c12
-       -2*0.500000000000000*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
-       -0.500000000000000*rho**2*Y[ip]**2*Y[ihe4]*lambda_he4_pphe3_he3
-       +0.500000000000000*rho*Y[ihe3]**2*lambda_he3_he3pp_he4
+       -3*1.66666666666667e-01*rho**2*Y[ihe4]**3*lambda_he4_aag_c12
+       -2*5.00000000000000e-01*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
+       -5.00000000000000e-01*rho**2*Y[ip]**2*Y[ihe4]*lambda_he4_pphe3_he3
+       +5.00000000000000e-01*rho*Y[ihe3]**2*lambda_he3_he3pp_he4
        +Y[ihe6]*lambda_he6_gnn_he4
        +2*rho*Y[it]*Y[ili7]*lambda_li7_tnna_he4
        )
@@ -225,7 +225,7 @@ def rhs(t, Y, rho, T):
 
     dYdt[ili7] = (
        -rho*Y[it]*Y[ili7]*lambda_li7_tnna_he4
-       +0.500000000000000*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
+       +5.00000000000000e-01*rho**3*Y[in]*Y[ip]*Y[ihe4]**2*lambda_he4_npahe3_li7
        )
 
     dYdt[ib17] = (
@@ -233,7 +233,7 @@ def rhs(t, Y, rho, T):
        )
 
     dYdt[ic12] = (
-       +0.166666666666667*rho**2*Y[ihe4]**3*lambda_he4_aag_c12
+       +1.66666666666667e-01*rho**2*Y[ihe4]**3*lambda_he4_aag_c12
        )
 
     dYdt[ic14] = (

--- a/test/standard/triple-alpha/triple-alpha_rhs.py
+++ b/test/standard/triple-alpha/triple-alpha_rhs.py
@@ -52,13 +52,13 @@ def rhs(t, Y, rho, T):
     dYdt = np.zeros((nnuc), dtype=np.float64)
 
     dYdt[ihe4] = (
-       -3*0.166666666666667*rho**2*Y[ihe4]**3*lambda_he4_aag_c12
+       -3*1.66666666666667e-01*rho**2*Y[ihe4]**3*lambda_he4_aag_c12
        +3*Y[ic12]*lambda_c12_gaa_he4
        )
 
     dYdt[ic12] = (
        -Y[ic12]*lambda_c12_gaa_he4
-       +0.166666666666667*rho**2*Y[ihe4]**3*lambda_he4_aag_c12
+       +1.66666666666667e-01*rho**2*Y[ihe4]**3*lambda_he4_aag_c12
        )
 
     return dYdt

--- a/test/standard/triple-alpha_f90/network.f90
+++ b/test/standard/triple-alpha_f90/network.f90
@@ -38,13 +38,13 @@ contains
 
     write(*,*) "T: ", T
     YDOT(net_meta%ihe4) = ( &
-       - 3 * 0.166666666666667 * dens**2 * Y(net_meta%ihe4)**3 * rxn_rates(net_meta%k_he4_aag_c12) &
+       - 3 * 1.66666666666667d-01 * dens**2 * Y(net_meta%ihe4)**3 * rxn_rates(net_meta%k_he4_aag_c12) &
        + 3 * Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_gaa_he4) &
        )
 
     YDOT(net_meta%ic12) = ( &
        - Y(net_meta%ic12) * rxn_rates(net_meta%k_c12_gaa_he4) &
-       + 0.166666666666667 * dens**2 * Y(net_meta%ihe4)**3 * rxn_rates(net_meta%k_he4_aag_c12) &
+       + 1.66666666666667d-01 * dens**2 * Y(net_meta%ihe4)**3 * rxn_rates(net_meta%k_he4_aag_c12) &
        )
 
 
@@ -103,7 +103,7 @@ contains
       ! DJAC(j, i) = d(YDOT(j))/dY(i)
 
       DJAC(net_meta%ihe4,net_meta%ihe4) = ( &
-         - 3 * 0.166666666666667 * dens**2 * 3*Y(net_meta%ihe4)**2 * rxn_rates(net_meta%k_he4_aag_c12) &
+         - 3 * 1.66666666666667d-01 * dens**2 * 3*Y(net_meta%ihe4)**2 * rxn_rates(net_meta%k_he4_aag_c12) &
          )
 
       DJAC(net_meta%ihe4,net_meta%ic12) = ( &
@@ -111,7 +111,7 @@ contains
          )
 
       DJAC(net_meta%ic12,net_meta%ihe4) = ( &
-         + 0.166666666666667 * dens**2 * 3*Y(net_meta%ihe4)**2 * rxn_rates(net_meta%k_he4_aag_c12) &
+         + 1.66666666666667d-01 * dens**2 * 3*Y(net_meta%ihe4)**2 * rxn_rates(net_meta%k_he4_aag_c12) &
          )
 
       DJAC(net_meta%ic12,net_meta%ic12) = ( &

--- a/test/test_reaclib.py
+++ b/test/test_reaclib.py
@@ -1,9 +1,12 @@
 # Test the examples against the outputs in their corresponding ./standard/... subdirectories
 from __future__ import print_function
 import os
+import sys
+import importlib
 import shutil
 import datetime
-import subprocess
+import time
+import difflib
 import nose.tools
 
 # Setup some directory names
@@ -36,42 +39,52 @@ def test_all():
         dir_std_tc = os.path.join(dir_standard, tc)
         os.mkdir(dir_tc)
         example_path = os.path.join(dir_examples, tc)
-        script_name = tc.split('_')[0].lower() + '.py'
+        script_module_name = tc.split('_')[0].lower()
         for file in os.listdir(example_path):
             shutil.copy(os.path.join(example_path, file), dir_tc)
         os.chdir(dir_tc)
 
+        # Add the test directory to path so I can import its script
+        sys.path.insert(0, dir_tc)
+
         # Run test case
-        pycall = subprocess.Popen(['python',script_name],
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE)
-        pycall_stdout, pycall_stderr = pycall.communicate()
+        mk = sys.modules.keys()
+        mk_before = mk[:]
+        tcmod = importlib.import_module(script_module_name)
+        mk = sys.modules.keys()
+        mk_after = mk[:]
 
-        if pycall_stderr:
-            print('Error in python call of script {}:'.format(os.path.join(dir_tc, script_name)))
-            print(pycall_stderr)
-            exit()
+        # Necessary if muliple test case paths use the same script name:
+        ## Remove test case module and modules it imported from module list
+        mk_to_del = list(set(mk_after)-set(mk_before))
+        for k in mk_to_del:
+            sys.modules.pop(k)
 
+        ## Remove test directory from path
+        sys.path.pop(0)
+        
         # Compare with standard
         for file in os.listdir(dir_std_tc):
             f_tc = os.path.join(dir_tc, file)
             f_std_tc = os.path.join(dir_std_tc, file)
-            diffcall = subprocess.Popen(['diff', f_tc, f_std_tc],
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE)
-            diffcall_stdout, diffcall_stderr = diffcall.communicate()
-
-            if diffcall_stderr:
-                print('Error in diff call between {} and {}:'.format(f_tc, f_std_tc))
-                print(diffcall_stderr.decode('utf-8'))
-                exit()
-
-            if diffcall_stdout!=b'':
-                print('--------------------')
-                print(file)
-                print(diffcall_stdout.decode('utf-8'))
-                print('--------------------')
-
-            yield nose.tools.assert_equals, diffcall_stdout, b''
+            try:
+                lines_tc = open(f_tc, 'U').readlines()
+                date_tc  = time.ctime(os.stat(f_tc).st_mtime)
+            except:
+                raise
+            try:
+                lines_std_tc = open(f_std_tc, 'U').readlines()
+                date_std_tc = time.ctime(os.stat(f_std_tc).st_mtime)
+            except:
+                raise
+            diff = difflib.unified_diff(lines_tc, lines_std_tc,
+                                        f_tc, f_std_tc,
+                                        date_tc, date_std_tc,
+                                        n=3)
+            diffreport = ''.join(diff)
+            if diffreport.strip() != b'':
+                print('')
+                print(diffreport)
+            yield nose.tools.assert_equals, diffreport.strip(), b''
     
 

--- a/test/test_reaclib.py
+++ b/test/test_reaclib.py
@@ -49,10 +49,10 @@ def test_all():
 
         # Run test case
         mk = sys.modules.keys()
-        mk_before = mk[:]
+        mk_before = [k for k in mk]
         tcmod = importlib.import_module(script_module_name)
         mk = sys.modules.keys()
-        mk_after = mk[:]
+        mk_after = [k for k in mk]
 
         # Necessary if muliple test case paths use the same script name:
         ## Remove test case module and modules it imported from module list
@@ -85,6 +85,6 @@ def test_all():
             if diffreport.strip() != b'':
                 print('')
                 print(diffreport)
-            yield nose.tools.assert_equals, diffreport.strip(), b''
+            yield nose.tools.assert_equals, diffreport.strip(), ''
     
 


### PR DESCRIPTION
closes #5 

**Pure python unit testing**
    
test_reaclib.py now eliminates the use of subprocess.Popen. Instead, it:

- Imports test case scripts as modules

- Un-Imports each test case module when finished with it, along with any modules it may have imported

(The above is necessary to allow different test cases to use the same script name, eg. cno.py for both examples/CNO and examples/CNO_f90)
    
- Uses the difflib library to compare the outputs instead of using subprocess.Popen to call diff

**Explicit Prefactor Precision**

- Rate.prefactor is now printed in scientific notation in both python and fortran output.

- In fortran output, the exponent character is 'd' instead of 'e' to declare it as a double-precision value, as per Doug's suggestion.

