### PR TITLE
Sort reactants after calling `set()`

### DIFF
--- a/pyreaclib/networks/base_fortran_network.py
+++ b/pyreaclib/networks/base_fortran_network.py
@@ -84,7 +84,7 @@ class BaseFortranNetwork(RateCollection):
 
         # composition dependence
         Y_string = ""
-        for n, r in enumerate(set(rate.reactants)):
+        for n, r in enumerate(sorted(set(rate.reactants))):
             c = rate.reactants.count(r)
             if c > 1:
                 Y_string += self.name_y + "(j{})**{}".format(r, c)
@@ -153,7 +153,7 @@ class BaseFortranNetwork(RateCollection):
 
         # composition dependence
         Y_sym = 1
-        for n, r in enumerate(set(rate.reactants)):
+        for n, r in enumerate(sorted(set(rate.reactants))):
             c = rate.reactants.count(r)
             sym_final = self.name_y + '(j{})'.format(r)
             sym_temp  = 'Y__j{}__'.format(r)
@@ -203,7 +203,7 @@ class BaseFortranNetwork(RateCollection):
 
         # composition dependence
         Y_string = ""
-        for n, r in enumerate(set(rate.reactants)):
+        for n, r in enumerate(sorted(set(rate.reactants))):
             c = rate.reactants.count(r)
             if y_i == r:
                 if c == 1:

--- a/pyreaclib/networks/python_network.py
+++ b/pyreaclib/networks/python_network.py
@@ -52,7 +52,7 @@ class PythonNetwork(RateCollection):
 
         # composition dependence
         Y_string = ""
-        for n, r in enumerate(set(rate.reactants)):
+        for n, r in enumerate(sorted(set(rate.reactants))):
             c = rate.reactants.count(r)
             if c > 1:
                 Y_string += "Y[i{}]**{}".format(r, c)
@@ -95,7 +95,7 @@ class PythonNetwork(RateCollection):
 
         # composition dependence
         Y_string = ""
-        for n, r in enumerate(set(rate.reactants)):
+        for n, r in enumerate(sorted(set(rate.reactants))):
             c = rate.reactants.count(r)
             if y_i == r:
                 if c == 1:


### PR DESCRIPTION
This is to ensure reactant strings are formed with nuclei in a consistent order.